### PR TITLE
chip animations

### DIFF
--- a/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.component.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.component.ts
@@ -1,0 +1,118 @@
+import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ChipAnimationService } from './chip-animation.service';
+import { getChipSymbolId } from '../../../shared/models/chip.models';
+
+@Component({
+  selector: 'app-chip-animation',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="chip-animation-layer">
+      @for (animation of animations(); track animation.config.id) {
+        @for (chip of animation.chips; track chip.id) {
+          <div
+            class="flying-chip"
+            [class.win-animation]="animation.config.type === 'win'"
+            [style.--from-x.px]="animation.config.fromPosition.x + chip.offsetX"
+            [style.--from-y.px]="animation.config.fromPosition.y + chip.offsetY"
+            [style.--to-x.px]="animation.config.toPosition.x + chip.offsetX"
+            [style.--to-y.px]="animation.config.toPosition.y + chip.offsetY"
+            [style.--duration.ms]="animation.config.durationMs"
+            [style.--delay.ms]="chip.delay"
+            [style.animation-delay.ms]="chip.delay"
+          >
+            <svg viewBox="0 0 100 100">
+              <use [attr.href]="getChipSymbolId(chip.color)" />
+            </svg>
+          </div>
+        }
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .chip-animation-layer {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 1000;
+        overflow: visible;
+      }
+
+      .flying-chip {
+        position: absolute;
+        width: 28px;
+        height: 28px;
+        left: 0;
+        top: 0;
+        animation: flyChip var(--duration, 400ms) ease-out forwards;
+        animation-delay: var(--delay, 0ms);
+        opacity: 0;
+        transform: translate(var(--from-x, 0), var(--from-y, 0));
+      }
+
+      .flying-chip svg {
+        width: 100%;
+        height: 100%;
+        filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.5));
+      }
+
+      .flying-chip.win-animation {
+        animation: flyChipWin var(--duration, 600ms) ease-in-out forwards;
+      }
+
+      @keyframes flyChip {
+        0% {
+          opacity: 1;
+          transform: translate(var(--from-x), var(--from-y)) scale(1);
+        }
+        50% {
+          transform: translate(
+              calc((var(--from-x) + var(--to-x)) / 2),
+              calc((var(--from-y) + var(--to-y)) / 2 - 30px)
+            )
+            scale(1.1);
+        }
+        100% {
+          opacity: 1;
+          transform: translate(var(--to-x), var(--to-y)) scale(1);
+        }
+      }
+
+      @keyframes flyChipWin {
+        0% {
+          opacity: 1;
+          transform: translate(var(--from-x), var(--from-y)) scale(1) rotate(0deg);
+        }
+        25% {
+          transform: translate(
+              calc(var(--from-x) + (var(--to-x) - var(--from-x)) * 0.25),
+              calc(var(--from-y) + (var(--to-y) - var(--from-y)) * 0.25 - 50px)
+            )
+            scale(1.2)
+            rotate(180deg);
+        }
+        75% {
+          transform: translate(
+              calc(var(--from-x) + (var(--to-x) - var(--from-x)) * 0.75),
+              calc(var(--from-y) + (var(--to-y) - var(--from-y)) * 0.75 - 20px)
+            )
+            scale(1.1)
+            rotate(360deg);
+        }
+        100% {
+          opacity: 1;
+          transform: translate(var(--to-x), var(--to-y)) scale(1) rotate(360deg);
+        }
+      }
+    `,
+  ],
+})
+export class ChipAnimationComponent {
+  private chipAnimationService = inject(ChipAnimationService);
+
+  animations = computed(() => this.chipAnimationService.activeAnimations());
+  getChipSymbolId = getChipSymbolId;
+}

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.component.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.component.ts
@@ -11,7 +11,141 @@ import { getChipSymbolId } from '../../../shared/models/chip.models';
   template: `
     <div class="chip-animation-layer">
       @for (animation of animations(); track animation.config.id) {
+        @for (chip of animation.chips; track chip.id) {import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ChipAnimationService } from './chip-animation.service';
+import { getChipSymbolId } from '../../../shared/models/chip.models';
+
+/**
+ * Overlay component responsible for rendering chip-flight animations across the UI.
+ * Animations are driven by ChipAnimationService, which maintains the current list
+ * of active animations and their chip instances.
+ */
+@Component({
+  selector: 'app-chip-animation',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <!-- Full-screen, non-interactive overlay layer for chip animations -->
+    <div class="chip-animation-layer">
+      @for (animation of animations(); track animation.config.id) {
         @for (chip of animation.chips; track chip.id) {
+          <div
+            class="flying-chip"
+            [class.win-animation]="animation.config.type === 'win'"
+            [style.--from-x.px]="animation.config.fromPosition.x + chip.offsetX"
+            [style.--from-y.px]="animation.config.fromPosition.y + chip.offsetY"
+            [style.--to-x.px]="animation.config.toPosition.x + chip.offsetX"
+            [style.--to-y.px]="animation.config.toPosition.y + chip.offsetY"
+            [style.--duration.ms]="animation.config.durationMs"
+            [style.--delay.ms]="chip.delay"
+            [style.animation-delay.ms]="chip.delay"
+          >
+            <!-- Render chip via SVG symbol reference to avoid duplicating SVG markup per chip -->
+            <svg viewBox="0 0 100 100">
+              <use [attr.href]="getChipSymbolId(chip.color)" />
+            </svg>
+          </div>
+        }
+      }
+    </div>
+  `,
+  styles: [
+    `
+      /* Fixed overlay that spans the viewport and does not intercept mouse/touch events */
+      .chip-animation-layer {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 1000;
+        overflow: visible;
+      }
+
+      /* Individual chip element that animates from a start point to an end point */
+      .flying-chip {
+        position: absolute;
+        width: 28px;
+        height: 28px;
+        left: 0;
+        top: 0;
+        animation: flyChip var(--duration, 400ms) ease-out forwards;
+        animation-delay: var(--delay, 0ms);
+        opacity: 0;
+        transform: translate(var(--from-x, 0), var(--from-y, 0));
+      }
+
+      /* Shadow to help chips read against the table felt and background */
+      .flying-chip svg {
+        width: 100%;
+        height: 100%;
+        filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.5));
+      }
+
+      /* Alternative keyframe set for "win" animations (more dramatic arc + rotation) */
+      .flying-chip.win-animation {
+        animation: flyChipWin var(--duration, 600ms) ease-in-out forwards;
+      }
+
+      /* Standard chip travel: arced midpoint path using CSS calc() between from/to */
+      @keyframes flyChip {
+        0% {
+          opacity: 1;
+          transform: translate(var(--from-x), var(--from-y)) scale(1);
+        }
+        50% {
+          transform: translate(
+              calc((var(--from-x) + var(--to-x)) / 2),
+              calc((var(--from-y) + var(--to-y)) / 2 - 30px)
+            )
+            scale(1.1);
+        }
+        100% {
+          opacity: 1;
+          transform: translate(var(--to-x), var(--to-y)) scale(1);
+        }
+      }
+
+      /* Win travel: staged path segments with rotation for a more celebratory feel */
+      @keyframes flyChipWin {
+        0% {
+          opacity: 1;
+          transform: translate(var(--from-x), var(--from-y)) scale(1) rotate(0deg);
+        }
+        25% {
+          transform: translate(
+              calc(var(--from-x) + (var(--to-x) - var(--from-x)) * 0.25),
+              calc(var(--from-y) + (var(--to-y) - var(--from-y)) * 0.25 - 50px)
+            )
+            scale(1.2)
+            rotate(180deg);
+        }
+        75% {
+          transform: translate(
+              calc(var(--from-x) + (var(--to-x) - var(--from-x)) * 0.75),
+              calc(var(--from-y) + (var(--to-y) - var(--from-y)) * 0.75 - 20px)
+            )
+            scale(1.1)
+            rotate(360deg);
+        }
+        100% {
+          opacity: 1;
+          transform: translate(var(--to-x), var(--to-y)) scale(1) rotate(360deg);
+        }
+      }
+    `,
+  ],
+})
+export class ChipAnimationComponent {
+  private chipAnimationService = inject(ChipAnimationService);
+
+  /** Reactive list of active animations currently being rendered. */
+  animations = computed(() => this.chipAnimationService.activeAnimations());
+
+  /** Map a chip color to the SVG symbol href used by the <use> element. */
+  getChipSymbolId = getChipSymbolId;
+}
+
           <div
             class="flying-chip"
             [class.win-animation]="animation.config.type === 'win'"
@@ -115,4 +249,5 @@ export class ChipAnimationComponent {
 
   animations = computed(() => this.chipAnimationService.activeAnimations());
   getChipSymbolId = getChipSymbolId;
+
 }

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.models.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.models.ts
@@ -1,0 +1,82 @@
+export type AnimationType = 'bet' | 'win' | 'pot-collect';
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface ChipAnimationConfig {
+  id: string;
+  type: AnimationType;
+  fromPosition: Position;
+  toPosition: Position;
+  amount: number;
+  chipCount: number;
+  delayMs: number;
+  durationMs: number;
+}
+
+export interface ActiveChipAnimation {
+  config: ChipAnimationConfig;
+  startTime: number;
+  chips: AnimatedChip[];
+}
+
+export interface AnimatedChip {
+  id: string;
+  color: 'white' | 'red' | 'blue' | 'green' | 'black';
+  offsetX: number;
+  offsetY: number;
+  delay: number;
+}
+
+export const ANIMATION_DEFAULTS = {
+  betDurationMs: 400,
+  winDurationMs: 600,
+  chipStaggerMs: 30,
+  maxChipsPerAnimation: 8,
+};
+
+export function generateAnimationId(): string {
+  return `chip-anim-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+export function calculateChipColors(amount: number, maxChips: number): AnimatedChip[] {
+  const chips: AnimatedChip[] = [];
+  const values: { color: AnimatedChip['color']; value: number }[] = [
+    { color: 'black', value: 100 },
+    { color: 'green', value: 25 },
+    { color: 'blue', value: 10 },
+    { color: 'red', value: 5 },
+    { color: 'white', value: 1 },
+  ];
+
+  let remaining = amount;
+  let chipIndex = 0;
+
+  for (const { color, value } of values) {
+    while (remaining >= value && chips.length < maxChips) {
+      chips.push({
+        id: `chip-${chipIndex}`,
+        color,
+        offsetX: (Math.random() - 0.5) * 20,
+        offsetY: (Math.random() - 0.5) * 10,
+        delay: chipIndex * ANIMATION_DEFAULTS.chipStaggerMs,
+      });
+      remaining -= value;
+      chipIndex++;
+    }
+  }
+
+  if (chips.length === 0 && amount > 0) {
+    chips.push({
+      id: 'chip-0',
+      color: 'white',
+      offsetX: 0,
+      offsetY: 0,
+      delay: 0,
+    });
+  }
+
+  return chips;
+}

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.models.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.models.ts
@@ -1,35 +1,79 @@
+/** Supported animation semantics for chip flights. */
 export type AnimationType = 'bet' | 'win' | 'pot-collect';
 
+/** Simple 2D coordinate in viewport/screen space (px). */
 export interface Position {
   x: number;
   y: number;
 }
 
+/**
+ * Configuration describing a single chip-flight animation.
+ * The service uses this to create chip instances and to drive CSS timing.
+ */
 export interface ChipAnimationConfig {
+  /** Unique identifier for this animation instance. */
   id: string;
+
+  /** Logical type of animation (used to select timing/visual treatment). */
   type: AnimationType;
+
+  /** Start position for the chip flight (px). */
   fromPosition: Position;
+
+  /** End position for the chip flight (px). */
   toPosition: Position;
+
+  /** Amount represented by the animation (used to derive chip colors/count). */
   amount: number;
+
+  /** Target number of chips to render (may be capped by defaults). */
   chipCount: number;
+
+  /** Delay before the animation starts (ms). */
   delayMs: number;
+
+  /** Duration of the chip flight (ms). */
   durationMs: number;
 }
 
+/**
+ * Runtime representation of an in-flight animation.
+ * Includes derived chip instances and timing metadata for cleanup/expiry.
+ */
 export interface ActiveChipAnimation {
+  /** Immutable config used to render and time the animation. */
   config: ChipAnimationConfig;
+
+  /** Timestamp captured when the animation was created (ms since epoch). */
   startTime: number;
+
+  /** Per-chip render data (color, offsets, per-chip delay). */
   chips: AnimatedChip[];
 }
 
+/**
+ * Per-chip instance data used by the overlay renderer.
+ * Offsets introduce slight scatter so the chips do not overlap perfectly.
+ */
 export interface AnimatedChip {
+  /** Unique identifier for the chip within an animation. */
   id: string;
+
+  /** Chip color denomination used to select the SVG symbol. */
   color: 'white' | 'red' | 'blue' | 'green' | 'black';
+
+  /** Random horizontal jitter applied to from/to positions (px). */
   offsetX: number;
+
+  /** Random vertical jitter applied to from/to positions (px). */
   offsetY: number;
+
+  /** Per-chip start delay used for staggered launches (ms). */
   delay: number;
 }
 
+/** Central defaults used for durations, staggering, and chip caps. */
 export const ANIMATION_DEFAULTS = {
   betDurationMs: 400,
   winDurationMs: 600,
@@ -41,6 +85,10 @@ export function generateAnimationId(): string {
   return `chip-anim-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 }
 
+/**
+ * Generate a list of chip instances based on an amount and a maximum chip count.
+ * Uses a simple greedy breakdown by denomination and assigns jitter + stagger.
+ */
 export function calculateChipColors(amount: number, maxChips: number): AnimatedChip[] {
   const chips: AnimatedChip[] = [];
   const values: { color: AnimatedChip['color']; value: number }[] = [

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.service.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.service.ts
@@ -1,73 +1,70 @@
-import { Injectable, signal } from '@angular/core';
-import {
-  type ChipAnimationConfig,
-  type ActiveChipAnimation,
-  type Position,
-  type AnimationType,
-  ANIMATION_DEFAULTS,
-  generateAnimationId,
-  calculateChipColors,
-} from './chip-animation.models';
+import { Injectable } from '@angular/core';
+import { type Position } from './chip-animation.models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class ChipAnimationService {
-  private _activeAnimations = signal<ActiveChipAnimation[]>([]);
-  readonly activeAnimations = this._activeAnimations.asReadonly();
-
-  animateBet(fromPosition: Position, toPosition: Position, amount: number): string {
-    return this.createAnimation('bet', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.betDurationMs);
+export class PositionTrackerService {
+  /**
+   * Resolve the on-screen center position of a player seat.
+   * Seats are identified via a data-seat-position attribute in the DOM.
+   */
+  getSeatPosition(seatPosition: string): Position | null {
+    const element = document.querySelector(`[data-seat-position="${seatPosition}"]`);
+    if (!element) return null;
+    return this.calculateCenterPosition(element as HTMLElement);
   }
 
-  animateWin(fromPosition: Position, toPosition: Position, amount: number): string {
-    return this.createAnimation('win', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.winDurationMs);
+  /**
+   * Resolve the position of the main pot.
+   * Currently delegates to getMainPotPosition for clarity and future extensibility.
+   */
+  getPotPosition(): Position | null {
+    return this.getMainPotPosition();
   }
 
-  animatePotCollect(fromPosition: Position, toPosition: Position, amount: number): string {
-    return this.createAnimation('pot-collect', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.betDurationMs);
+  /**
+   * Resolve the on-screen center position of the main pot element.
+   * The main pot is identified via a data-pot-type="main" attribute.
+   */
+  getMainPotPosition(): Position | null {
+    const element = document.querySelector('[data-pot-type="main"]');
+    if (!element) return null;
+    return this.calculateCenterPosition(element as HTMLElement);
   }
 
-  private createAnimation(
-    type: AnimationType,
-    fromPosition: Position,
-    toPosition: Position,
-    amount: number,
-    durationMs: number
-  ): string {
-    const id = generateAnimationId();
-    const chips = calculateChipColors(amount, ANIMATION_DEFAULTS.maxChipsPerAnimation);
+  /**
+   * Resolve the on-screen center position of a side pot by index.
+   * Used when side pots are rendered in a deterministic order.
+   */
+  getSidePotPosition(index: number): Position | null {
+    const element = document.querySelector(`[data-pot-type="side"][data-pot-index="${index}"]`);
+    if (!element) return null;
+    return this.calculateCenterPosition(element as HTMLElement);
+  }
 
-    const config: ChipAnimationConfig = {
-      id,
-      type,
-      fromPosition,
-      toPosition,
-      amount,
-      chipCount: chips.length,
-      delayMs: 0,
-      durationMs,
+  /**
+   * Resolve the on-screen center position of a side pot by unique pot id.
+   * Useful when side pots are keyed by an identifier rather than index.
+   */
+  getSidePotPositionById(potId: string): Position | null {
+    const element = document.querySelector(`[data-pot-type="side"][data-pot-id="${potId}"]`);
+    if (!element) return null;
+    return this.calculateCenterPosition(element as HTMLElement);
+  }
+
+  /**
+   * Calculate the center point of an element in viewport coordinates.
+   * Returns null if the element has no rendered size (e.g., not visible yet).
+   */
+  private calculateCenterPosition(element: HTMLElement): Position | null {
+    const rect = element.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      return null;
+    }
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
     };
-
-    const animation: ActiveChipAnimation = {
-      config,
-      startTime: Date.now(),
-      chips,
-    };
-
-    this._activeAnimations.update((anims) => [...anims, animation]);
-
-    const totalDuration = durationMs + chips.length * ANIMATION_DEFAULTS.chipStaggerMs + 100;
-    setTimeout(() => this.removeAnimation(id), totalDuration);
-
-    return id;
-  }
-
-  private removeAnimation(id: string): void {
-    this._activeAnimations.update((anims) => anims.filter((a) => a.config.id !== id));
-  }
-
-  clearAll(): void {
-    this._activeAnimations.set([]);
   }
 }

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.service.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.service.ts
@@ -1,70 +1,85 @@
-import { Injectable } from '@angular/core';
-import { type Position } from './chip-animation.models';
+import { Injectable, signal } from '@angular/core';
+import {
+  type ChipAnimationConfig,
+  type ActiveChipAnimation,
+  type Position,
+  type AnimationType,
+  ANIMATION_DEFAULTS,
+  generateAnimationId,
+  calculateChipColors,
+} from './chip-animation.models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class PositionTrackerService {
-  /**
-   * Resolve the on-screen center position of a player seat.
-   * Seats are identified via a data-seat-position attribute in the DOM.
-   */
-  getSeatPosition(seatPosition: string): Position | null {
-    const element = document.querySelector(`[data-seat-position="${seatPosition}"]`);
-    if (!element) return null;
-    return this.calculateCenterPosition(element as HTMLElement);
+export class ChipAnimationService {
+  /** Internal signal holding the currently active chip-flight animations. */
+  private _activeAnimations = signal<ActiveChipAnimation[]>([]);
+
+  /** Read-only view of active animations for renderers (e.g., ChipAnimationComponent). */
+  readonly activeAnimations = this._activeAnimations.asReadonly();
+
+  /** Animate chips moving from a player/seat position to the pot (or similar bet target). */
+  animateBet(fromPosition: Position, toPosition: Position, amount: number): string {
+    return this.createAnimation('bet', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.betDurationMs);
+  }
+
+  /** Animate chips moving to a winner/seat position (uses the win duration styling/timing). */
+  animateWin(fromPosition: Position, toPosition: Position, amount: number): string {
+    return this.createAnimation('win', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.winDurationMs);
+  }
+
+  /** Animate chips moving from the pot to a destination (e.g., winner collects pot). */
+  animatePotCollect(fromPosition: Position, toPosition: Position, amount: number): string {
+    return this.createAnimation('pot-collect', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.betDurationMs);
   }
 
   /**
-   * Resolve the position of the main pot.
-   * Currently delegates to getMainPotPosition for clarity and future extensibility.
+   * Create and register a new animation instance.
+   * Generates chip instances (colors, offsets, stagger delays) and schedules removal once complete.
    */
-  getPotPosition(): Position | null {
-    return this.getMainPotPosition();
-  }
+  private createAnimation(
+    type: AnimationType,
+    fromPosition: Position,
+    toPosition: Position,
+    amount: number,
+    durationMs: number
+  ): string {
+    const id = generateAnimationId();
+    const chips = calculateChipColors(amount, ANIMATION_DEFAULTS.maxChipsPerAnimation);
 
-  /**
-   * Resolve the on-screen center position of the main pot element.
-   * The main pot is identified via a data-pot-type="main" attribute.
-   */
-  getMainPotPosition(): Position | null {
-    const element = document.querySelector('[data-pot-type="main"]');
-    if (!element) return null;
-    return this.calculateCenterPosition(element as HTMLElement);
-  }
-
-  /**
-   * Resolve the on-screen center position of a side pot by index.
-   * Used when side pots are rendered in a deterministic order.
-   */
-  getSidePotPosition(index: number): Position | null {
-    const element = document.querySelector(`[data-pot-type="side"][data-pot-index="${index}"]`);
-    if (!element) return null;
-    return this.calculateCenterPosition(element as HTMLElement);
-  }
-
-  /**
-   * Resolve the on-screen center position of a side pot by unique pot id.
-   * Useful when side pots are keyed by an identifier rather than index.
-   */
-  getSidePotPositionById(potId: string): Position | null {
-    const element = document.querySelector(`[data-pot-type="side"][data-pot-id="${potId}"]`);
-    if (!element) return null;
-    return this.calculateCenterPosition(element as HTMLElement);
-  }
-
-  /**
-   * Calculate the center point of an element in viewport coordinates.
-   * Returns null if the element has no rendered size (e.g., not visible yet).
-   */
-  private calculateCenterPosition(element: HTMLElement): Position | null {
-    const rect = element.getBoundingClientRect();
-    if (rect.width === 0 && rect.height === 0) {
-      return null;
-    }
-    return {
-      x: rect.left + rect.width / 2,
-      y: rect.top + rect.height / 2,
+    const config: ChipAnimationConfig = {
+      id,
+      type,
+      fromPosition,
+      toPosition,
+      amount,
+      chipCount: chips.length,
+      delayMs: 0,
+      durationMs,
     };
+
+    const animation: ActiveChipAnimation = {
+      config,
+      startTime: Date.now(),
+      chips,
+    };
+
+    this._activeAnimations.update((anims) => [...anims, animation]);
+
+    const totalDuration = durationMs + chips.length * ANIMATION_DEFAULTS.chipStaggerMs + 100;
+    setTimeout(() => this.removeAnimation(id), totalDuration);
+
+    return id;
+  }
+
+  /** Remove a specific animation by id once it has completed. */
+  private removeAnimation(id: string): void {
+    this._activeAnimations.update((anims) => anims.filter((a) => a.config.id !== id));
+  }
+
+  /** Immediately clear all active animations (e.g., route change, table reset). */
+  clearAll(): void {
+    this._activeAnimations.set([]);
   }
 }

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.service.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/chip-animation.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, signal } from '@angular/core';
+import {
+  type ChipAnimationConfig,
+  type ActiveChipAnimation,
+  type Position,
+  type AnimationType,
+  ANIMATION_DEFAULTS,
+  generateAnimationId,
+  calculateChipColors,
+} from './chip-animation.models';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ChipAnimationService {
+  private _activeAnimations = signal<ActiveChipAnimation[]>([]);
+  readonly activeAnimations = this._activeAnimations.asReadonly();
+
+  animateBet(fromPosition: Position, toPosition: Position, amount: number): string {
+    return this.createAnimation('bet', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.betDurationMs);
+  }
+
+  animateWin(fromPosition: Position, toPosition: Position, amount: number): string {
+    return this.createAnimation('win', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.winDurationMs);
+  }
+
+  animatePotCollect(fromPosition: Position, toPosition: Position, amount: number): string {
+    return this.createAnimation('pot-collect', fromPosition, toPosition, amount, ANIMATION_DEFAULTS.betDurationMs);
+  }
+
+  private createAnimation(
+    type: AnimationType,
+    fromPosition: Position,
+    toPosition: Position,
+    amount: number,
+    durationMs: number
+  ): string {
+    const id = generateAnimationId();
+    const chips = calculateChipColors(amount, ANIMATION_DEFAULTS.maxChipsPerAnimation);
+
+    const config: ChipAnimationConfig = {
+      id,
+      type,
+      fromPosition,
+      toPosition,
+      amount,
+      chipCount: chips.length,
+      delayMs: 0,
+      durationMs,
+    };
+
+    const animation: ActiveChipAnimation = {
+      config,
+      startTime: Date.now(),
+      chips,
+    };
+
+    this._activeAnimations.update((anims) => [...anims, animation]);
+
+    const totalDuration = durationMs + chips.length * ANIMATION_DEFAULTS.chipStaggerMs + 100;
+    setTimeout(() => this.removeAnimation(id), totalDuration);
+
+    return id;
+  }
+
+  private removeAnimation(id: string): void {
+    this._activeAnimations.update((anims) => anims.filter((a) => a.config.id !== id));
+  }
+
+  clearAll(): void {
+    this._activeAnimations.set([]);
+  }
+}

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/index.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/index.ts
@@ -1,0 +1,13 @@
+export { ChipAnimationComponent } from './chip-animation.component';
+export { ChipAnimationService } from './chip-animation.service';
+export { PositionTrackerService } from './position-tracker.service';
+export {
+  type AnimationType,
+  type Position,
+  type ChipAnimationConfig,
+  type ActiveChipAnimation,
+  type AnimatedChip,
+  ANIMATION_DEFAULTS,
+  generateAnimationId,
+  calculateChipColors,
+} from './chip-animation.models';

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/index.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/index.ts
@@ -1,6 +1,22 @@
+/**
+ * Public barrel exports for the chip animation subsystem.
+ * Consumers should import from this index rather than individual files
+ * to keep dependencies stable and encapsulated.
+ */
+
+/** Overlay component responsible for rendering chip-flight animations. */
 export { ChipAnimationComponent } from './chip-animation.component';
+
+/** Service used to trigger and manage chip animations across the app. */
 export { ChipAnimationService } from './chip-animation.service';
+
+/** Utility service for tracking DOM element positions in screen space. */
 export { PositionTrackerService } from './position-tracker.service';
+
+/**
+ * Core animation models, types, and helpers.
+ * These define the animation contracts and chip generation logic.
+ */
 export {
   type AnimationType,
   type Position,

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/position-tracker.service.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/position-tracker.service.ts
@@ -5,34 +5,58 @@ import { type Position } from './chip-animation.models';
   providedIn: 'root',
 })
 export class PositionTrackerService {
+  /**
+   * Resolve the on-screen center position of a player seat.
+   * Seats are identified via a data-seat-position attribute in the DOM.
+   */
   getSeatPosition(seatPosition: string): Position | null {
     const element = document.querySelector(`[data-seat-position="${seatPosition}"]`);
     if (!element) return null;
     return this.calculateCenterPosition(element as HTMLElement);
   }
 
+  /**
+   * Resolve the position of the main pot.
+   * Currently delegates to getMainPotPosition for clarity and future extensibility.
+   */
   getPotPosition(): Position | null {
     return this.getMainPotPosition();
   }
 
+  /**
+   * Resolve the on-screen center position of the main pot element.
+   * The main pot is identified via a data-pot-type="main" attribute.
+   */
   getMainPotPosition(): Position | null {
     const element = document.querySelector('[data-pot-type="main"]');
     if (!element) return null;
     return this.calculateCenterPosition(element as HTMLElement);
   }
 
+  /**
+   * Resolve the on-screen center position of a side pot by index.
+   * Used when side pots are rendered in a deterministic order.
+   */
   getSidePotPosition(index: number): Position | null {
     const element = document.querySelector(`[data-pot-type="side"][data-pot-index="${index}"]`);
     if (!element) return null;
     return this.calculateCenterPosition(element as HTMLElement);
   }
 
+  /**
+   * Resolve the on-screen center position of a side pot by unique pot id.
+   * Useful when side pots are keyed by an identifier rather than index.
+   */
   getSidePotPositionById(potId: string): Position | null {
     const element = document.querySelector(`[data-pot-type="side"][data-pot-id="${potId}"]`);
     if (!element) return null;
     return this.calculateCenterPosition(element as HTMLElement);
   }
 
+  /**
+   * Calculate the center point of an element in viewport coordinates.
+   * Returns null if the element has no rendered size (e.g., not visible yet).
+   */
   private calculateCenterPosition(element: HTMLElement): Position | null {
     const rect = element.getBoundingClientRect();
     if (rect.width === 0 && rect.height === 0) {

--- a/src/LowRollers.Web/src/app/features/game/chip-animation/position-tracker.service.ts
+++ b/src/LowRollers.Web/src/app/features/game/chip-animation/position-tracker.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { type Position } from './chip-animation.models';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PositionTrackerService {
+  getSeatPosition(seatPosition: string): Position | null {
+    const element = document.querySelector(`[data-seat-position="${seatPosition}"]`);
+    if (!element) return null;
+    return this.calculateCenterPosition(element as HTMLElement);
+  }
+
+  getPotPosition(): Position | null {
+    return this.getMainPotPosition();
+  }
+
+  getMainPotPosition(): Position | null {
+    const element = document.querySelector('[data-pot-type="main"]');
+    if (!element) return null;
+    return this.calculateCenterPosition(element as HTMLElement);
+  }
+
+  getSidePotPosition(index: number): Position | null {
+    const element = document.querySelector(`[data-pot-type="side"][data-pot-index="${index}"]`);
+    if (!element) return null;
+    return this.calculateCenterPosition(element as HTMLElement);
+  }
+
+  getSidePotPositionById(potId: string): Position | null {
+    const element = document.querySelector(`[data-pot-type="side"][data-pot-id="${potId}"]`);
+    if (!element) return null;
+    return this.calculateCenterPosition(element as HTMLElement);
+  }
+
+  private calculateCenterPosition(element: HTMLElement): Position | null {
+    const rect = element.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      return null;
+    }
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  }
+}

--- a/src/LowRollers.Web/src/app/features/game/player-seat/player-seat.component.ts
+++ b/src/LowRollers.Web/src/app/features/game/player-seat/player-seat.component.ts
@@ -79,7 +79,12 @@ const SEAT_POSITIONS: Record<SeatPosition, Record<string, string>> = {
   imports: [CommonModule, CardComponent, ActionTimerComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="player-seat" [ngStyle]="seatPositionStyle()" [class.empty-seat]="!player()">
+    <div
+      class="player-seat"
+      [attr.data-seat-position]="position()"
+      [ngStyle]="seatPositionStyle()"
+      [class.empty-seat]="!player()"
+    >
       @if (player(); as p) {
         <!-- Occupied seat -->
         <div

--- a/src/LowRollers.Web/src/app/features/game/poker-table/poker-table.component.ts
+++ b/src/LowRollers.Web/src/app/features/game/poker-table/poker-table.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CommunityCardsComponent } from '../community-cards';
 import { PotDisplayComponent, type Pot } from '../pot-display';
+import { ChipAnimationComponent } from '../chip-animation';
 import { Card } from '../../../shared/models/card.models';
 
 /** Position identifiers for seats around the table */
@@ -63,13 +64,13 @@ const DEALER_BUTTON_POSITIONS: Record<SeatPosition, string> = {
 
 /**
  * Main poker table component displaying the oval table,
- * community cards, pot, and dealer button.
+ * community cards, pot, dealer button, and chip animations.
  * Player seats are projected via ng-content.
  */
 @Component({
   selector: 'app-poker-table',
   standalone: true,
-  imports: [CommonModule, CommunityCardsComponent, PotDisplayComponent],
+  imports: [CommonModule, CommunityCardsComponent, PotDisplayComponent, ChipAnimationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="table-area">
@@ -105,6 +106,9 @@ const DEALER_BUTTON_POSITIONS: Record<SeatPosition, string> = {
 
         <!-- Player Seat Slots (content projected) -->
         <ng-content></ng-content>
+
+        <!-- Chip Animation Overlay -->
+        <app-chip-animation />
       </div>
     </div>
   `,

--- a/src/LowRollers.Web/src/app/features/game/pot-display/pot-display.component.ts
+++ b/src/LowRollers.Web/src/app/features/game/pot-display/pot-display.component.ts
@@ -38,38 +38,50 @@ const CURRENCY_FORMATTER = new Intl.NumberFormat('en-US', {
   imports: [CommonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    @if (mainPot(); as pot) {
+    @if (pots().length > 0) {
       <div class="pot-display" role="region" aria-label="Pot display">
         <!-- All pots in a row -->
         <div class="pots-row">
           <!-- Main Pot -->
-          <div class="pot-container main-pot" [class.animating]="isAnimating()">
-            <div class="pot-chips" aria-hidden="true">
-              @for (stack of mainPotChips(); track stack.color; let colIdx = $index) {
-                <div
-                  class="chip-column"
-                  [style.animation-delay.ms]="colIdx * 50"
-                  [class.animate-in]="isAnimating()"
-                >
-                  @for (i of createChipArray(stack.count); track i) {
-                    <div class="chip">
-                      <svg viewBox="0 0 100 100">
-                        <use [attr.href]="getChipSymbolId(stack.color)" />
-                      </svg>
-                    </div>
-                  }
-                </div>
-              }
+          @if (mainPot(); as pot) {
+            <div
+              class="pot-container main-pot"
+              data-pot-type="main"
+              [class.animating]="isAnimating()"
+            >
+              <div class="pot-chips" aria-hidden="true">
+                @for (stack of mainPotChips(); track stack.color; let colIdx = $index) {
+                  <div
+                    class="chip-column"
+                    [style.animation-delay.ms]="colIdx * 50"
+                    [class.animate-in]="isAnimating()"
+                  >
+                    @for (i of createChipArray(stack.count); track i) {
+                      <div class="chip">
+                        <svg viewBox="0 0 100 100">
+                          <use [attr.href]="getChipSymbolId(stack.color)" />
+                        </svg>
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+              <div class="pot-info">
+                <div class="pot-label">Main Pot</div>
+                <div class="pot-amount">{{ formatCurrency(pot.amount) }}</div>
+              </div>
             </div>
-            <div class="pot-info">
-              <div class="pot-label">Main Pot</div>
-              <div class="pot-amount">{{ formatCurrency(pot.amount) }}</div>
-            </div>
-          </div>
+          }
 
           <!-- Side Pots -->
           @for (sidePot of sidePots(); track sidePot.id; let idx = $index) {
-            <div class="pot-container side-pot" [class.animating]="isAnimating()">
+            <div
+              class="pot-container side-pot"
+              data-pot-type="side"
+              [attr.data-pot-index]="idx"
+              [attr.data-pot-id]="sidePot.id"
+              [class.animating]="isAnimating()"
+            >
               <div class="pot-chips" aria-hidden="true">
                 @for (
                   stack of sidePotChipsMap().get(sidePot.id) ?? [];
@@ -104,8 +116,8 @@ const CURRENCY_FORMATTER = new Intl.NumberFormat('en-US', {
           }
         </div>
 
-        <!-- Total (shown when side pots exist) -->
-        @if (sidePots().length > 0) {
+        <!-- Total (shown when side pots exist and a main pot is present) -->
+        @if (sidePots().length > 0 && mainPot()) {
           <div class="total-display">
             <span class="total-label">Total:</span>
             <span class="total-amount">{{ formatCurrency(totalAmount()) }}</span>
@@ -173,10 +185,6 @@ const CURRENCY_FORMATTER = new Intl.NumberFormat('en-US', {
         margin-bottom: 0;
       }
 
-      .pot-chips.small .chip:first-child {
-        margin-bottom: 0;
-      }
-
       .chip svg {
         width: 100%;
         height: 100%;
@@ -195,8 +203,12 @@ const CURRENCY_FORMATTER = new Intl.NumberFormat('en-US', {
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
       }
 
-      .pot-info.small {
-        padding: 6px 12px;
+      .pot-info.side {
+        background: linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(37, 99, 235, 0.2));
+        border: 2px solid rgba(96, 165, 250, 0.5);
+        box-shadow:
+          0 4px 12px rgba(0, 0, 0, 0.3),
+          inset 0 1px 1px rgba(255, 255, 255, 0.1);
       }
 
       .pot-label {


### PR DESCRIPTION
## Chip Animation Feature
> note, this has incorporated pull request https://github.com/stewart-southwell/lowrollers/pull/1, which should hopefully be non controversial.
> let me know if you want my test script as well, it's kinda long

Implemented animated chip movements for betting (player → pot) and winning (pot → player) scenarios. Position tracking uses data attributes on DOM elements (`data-seat-position`, `data-pot-type`, `data-pot-id`) queried directly via `document.querySelector()` at animation time, avoiding stale element reference issues encountered with stored references. Side pots are identified by stable IDs rather than array indices to prevent position lookup failures when preceding pots are removed. Animation coordination deducts chips from the source immediately, plays the animation, then credits the destination upon completion.

### Modified Files

| File | Changes |
|------|---------|
| `poker-table.component.ts` | Added `<app-chip-animation />` component to template |
| `player-seat.component.ts` | Added `[attr.data-seat-position]` attribute for position tracking |
| `pot-display.component.ts` | Added `data-pot-type`, `data-pot-id`, `data-pot-index` attributes; changed outer conditional to `pots().length > 0` so side pots remain visible when main pot empties |

### New Files

| File | Purpose |
|------|---------|
| `chip-animation/chip-animation.models.ts` | Type definitions and utility functions for chip calculations |
| `chip-animation/chip-animation.service.ts` | Injectable service to trigger bet/win animations |
| `chip-animation/chip-animation.component.ts` | Renders animated flying chips with CSS keyframe animations |
| `chip-animation/position-tracker.service.ts` | Queries DOM for element positions using data attribute selectors |
| `chip-animation/index.ts` | Barrel exports for the chip-animation module |